### PR TITLE
Add failing test for a sequence of drag and drop by offset and element

### DIFF
--- a/dotnet/test/common/Interactions/DragAndDropTest.cs
+++ b/dotnet/test/common/Interactions/DragAndDropTest.cs
@@ -58,6 +58,22 @@ namespace OpenQA.Selenium.Interactions
 
         [Test]
         [Category("Javascript")]
+        [IgnoreBrowser(Browser.HtmlUnit)]
+        [IgnoreBrowser(Browser.Android, "Mobile browser does not support drag-and-drop")]
+        [IgnoreBrowser(Browser.IPhone, "Mobile browser does not support drag-and-drop")]
+        [IgnoreBrowser(Browser.Safari, "Advanced User Interactions not implmented on Safari")]
+        public void DragAndDropRelativeAndToElement()
+        {
+            driver.Url = dragAndDropPage;
+            IWebElement img1 = driver.FindElement(By.Id("test1"));
+            IWebElement img2 = driver.FindElement(By.Id("test2"));
+            Actions actionProvider = new Actions(driver);
+            actionProvider.DragAndDropToOffset(img1, 100, 100).DragAndDrop(img2, img1).Perform();
+            Assert.AreEqual(img1.Location, img2.Location);
+        }
+
+        [Test]
+        [Category("Javascript")]
         public void DragAndDropToElementInIframe()
         {
             driver.Url = iframePage;


### PR DESCRIPTION
The test would fail on IE11 + Win 10:

Failed : OpenQA.Selenium.Interactions.DragAndDropTest.DragAndDropRelativeAndToElement
  Expected: {X=8,Y=8}
  But was:  {X=8,Y=26}

- [ ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
